### PR TITLE
Issue 46 - Handle tracked stats during backward game movement

### DIFF
--- a/src/components/YearRecap.tsx
+++ b/src/components/YearRecap.tsx
@@ -45,7 +45,7 @@ import { theme, darkTheme } from './theme';
 
 export class YearRecap extends React.Component<YearRecapProps> {
 	render() {
-		const thisYearStart = this.props.yearlyTrackedStats[this.props.year - 1];
+		const thisYearStart = this.props.yearRangeInitialStats[this.props.year - 1];
 		if (!thisYearStart) {
 			throw new Error(
 				`Could not find stats for the start of year ${this.props.year} (index ${
@@ -404,7 +404,7 @@ export interface YearRecapProps
 		TrackedStats {
 	selectedProjects: symbol[];
 	completedProjects: CompletedProject[];
-	yearlyTrackedStats: TrackedStats[];
+	yearRangeInitialStats: TrackedStats[];
 	/**
 	 * @param yearFinalStats The final stats for the year, including hidden surprises.
 	 */


### PR DESCRIPTION
#46 

-implement logic to rewind completed projects, reset selected projects, update stats when we go back a year(s) range
-Changed name of 'yearlyTrackedStats' to 'yearRangeInitialStats' - it seems like this array's objects MOSTLY are kept unmodified though rebates change). Not going to rework any of this yet since it doesn't seem to adversely affect the game.