### PR TITLE
Issue 26 - Show consolidated utility rebates at YearRecap

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -68,6 +68,14 @@ $blur-radius: 5px;
 	}
 }
 
+.year-recap-rebate-surprise {
+	background: linear-gradient(to right bottom, rgba(63, 163, 0, 1), rgb(80, 161, 0) 120%)!important;
+	// color: rgba(255, 255, 255, 0.9)!important;
+	& .emphasis {
+		color: white;
+	}
+}
+
 .year-recap-hidden-surprise {
 	background: linear-gradient(to right bottom, rgba(251, 67, 67, 98%), rgb(147, 39, 39) 120%)!important;
 	// color: rgba(255, 255, 255, 0.9)!important;

--- a/src/PageControls.tsx
+++ b/src/PageControls.tsx
@@ -23,7 +23,6 @@ import { newYearRecapControl } from './components/YearRecap';
 import { newGroupedChoicesControl } from './components/GroupedChoices';
 import { newInfoDialogControl } from './components/InfoDialog';
 
-let st = performance.now(); // Performance measurement
 
 declare interface PageControls {
 	[key: symbol]: PageControl;
@@ -320,5 +319,3 @@ export function projectCostAndCO2ReductionCards(projectCost: number, co2Reductio
 		}
 	];
 }
-
-console.log('PageControls', performance.now() - st);


### PR DESCRIPTION
#26 

- Showing consolidated utility rebates at EOY recap
- Remove surprise dialogs
- hiddenSurprises (used to be the roadblock/bad surprises) are now just recapSurprises. In the future can use this array to store individualized surpises good or bad that don't fit utility rebates
- Remove some unecessary comments, other small fixes