### PR TITLE
Issue 26  - Needs Verification Fixes

### DIFF
--- a/src/Projects.tsx
+++ b/src/Projects.tsx
@@ -98,9 +98,9 @@ declare interface ProjectControlParams {
 	 */
 	statsActualAppliers: TrackedStatsApplier;
 	/**
-	 * HIDDEN numbers that appear AFTER PROCEED is clicked (after they've committed to the selected projects). TODO IMPLEMENT
+	 * Stats that are applied at year end (or year range) recap
 	 */
-	statsHiddenAppliers?: TrackedStatsApplier;
+	statsRecapAppliers?: TrackedStatsApplier;
 	/**
 	 * Full title of the project, displayed on the choice info popup and the recap page.
 	 */
@@ -175,7 +175,7 @@ export class ProjectControl implements ProjectControlParams {
 	cost: number;
 	statsInfoAppliers: TrackedStatsApplier;
 	statsActualAppliers: TrackedStatsApplier;
-	statsHiddenAppliers?: TrackedStatsApplier;
+	statsRecapAppliers?: TrackedStatsApplier;
 	title: string;
 	shortTitle: string;
 	choiceInfoText: string | string[];
@@ -201,7 +201,7 @@ export class ProjectControl implements ProjectControlParams {
 		this.pageId = params.pageId;
 		this.statsInfoAppliers = params.statsInfoAppliers;
 		this.statsActualAppliers = params.statsActualAppliers;
-		this.statsHiddenAppliers = params.statsHiddenAppliers;
+		this.statsRecapAppliers = params.statsRecapAppliers;
 		this.title = params.title;
 		this.shortTitle = params.shortTitle;
 		this.choiceInfoText = params.choiceInfoText;
@@ -294,8 +294,8 @@ export class ProjectControl implements ProjectControlParams {
 		if (this.statsActualAppliers.totalRebates) {
 			total += this.statsActualAppliers.totalRebates.modifier
 		}
-		if (this.statsHiddenAppliers?.totalRebates) {
-			total += this.statsHiddenAppliers.totalRebates.modifier;
+		if (this.statsRecapAppliers?.totalRebates) {
+			total += this.statsRecapAppliers.totalRebates.modifier;
 		}
 		return total;
 	}
@@ -304,7 +304,7 @@ export class ProjectControl implements ProjectControlParams {
 	 * Returns the extra hidden costs of the projects (via the `moneySpent` stat key)
 	 */
 	getHiddenCost(): number {
-		return (this.statsHiddenAppliers && this.statsHiddenAppliers.moneySpent) ? this.statsHiddenAppliers.moneySpent.modifier : 0;
+		return (this.statsRecapAppliers && this.statsRecapAppliers.moneySpent) ? this.statsRecapAppliers.moneySpent.modifier : 0;
 	}
 
 	/**
@@ -449,7 +449,7 @@ Projects[Pages.wasteHeatRecovery] = new ProjectControl({
 		naturalGasMMBTU: absolute(-250),
 	},
 	// Stats that are HIDDEN until AFTER the user commits to the next year. 
-	statsHiddenAppliers: {
+	statsRecapAppliers: {
 		totalRebates: absolute(5_000),
 	},
 	title: 'Energy Efficiency - Waste Heat Recovery',
@@ -583,7 +583,7 @@ Projects[Pages.lightingUpgrades] = new ProjectControl({
 	statsActualAppliers: {
 		electricityUseKWh: relative(-0.125),
 	},
-	statsHiddenAppliers: {
+	statsRecapAppliers: {
 		totalRebates: absolute(7_500),
 	},
 	title: 'Energy Efficiency – Lighting Upgrades',
@@ -632,7 +632,7 @@ Projects[Pages.solarPanelsCarPort] = new ProjectControl({
 	statsActualAppliers: {
 		electricityUseKWh: relative(-0.125),
 	},
-	statsHiddenAppliers: {
+	statsRecapAppliers: {
 		financesAvailable: absolute(-30_000),
 		moneySpent: absolute(30_000),
 	},
@@ -882,7 +882,7 @@ Projects[Pages.compressedAirSystemImprovemnt] = new ProjectControl({
 	statsActualAppliers: {
 		electricityUseKWh: relative(-0.08),
 	},
-	statsHiddenAppliers: {
+	statsRecapAppliers: {
 		totalRebates: absolute(5_000),
 	},
 	utilityRebateValue: 5000,
@@ -1041,7 +1041,7 @@ Projects[Pages.improveLightingSystems] = new ProjectControl({
 	statsActualAppliers: {
 		electricityUseKWh: relative(-0.04),
 	},
-	statsHiddenAppliers: {
+	statsRecapAppliers: {
 		totalRebates: absolute(10_000),
 	},
 	utilityRebateValue: 10000,
@@ -1105,7 +1105,7 @@ Projects[Pages.installVFDs1] = new ProjectControl({
 	statsActualAppliers: {
 		electricityUseKWh: relative(-0.04),
 	},
-	statsHiddenAppliers: {
+	statsRecapAppliers: {
 		totalRebates: absolute(5_000),
 	},
 	utilityRebateValue: 5000,
@@ -1139,7 +1139,7 @@ Projects[Pages.installVFDs2] = new ProjectControl({
 	statsActualAppliers: {
 		electricityUseKWh: relative(-0.04),
 	},
-	statsHiddenAppliers: {
+	statsRecapAppliers: {
 		totalRebates: absolute(5_000),
 	},
 	utilityRebateValue: 5000,
@@ -1174,7 +1174,7 @@ Projects[Pages.installVFDs3] = new ProjectControl({
 	statsActualAppliers: {
 		electricityUseKWh: relative(-0.04),
 	},
-	statsHiddenAppliers: {
+	statsRecapAppliers: {
 		totalRebates: absolute(5_000),
 	},
 	utilityRebateValue: 5000,

--- a/src/Projects.tsx
+++ b/src/Projects.tsx
@@ -287,6 +287,20 @@ export class ProjectControl implements ProjectControlParams {
 	}
 
 	/**
+	 * Returns the total amount of in-year and end-of-year rebates of this project.
+	 */
+	getYearEndRebates(): number {
+		let total = 0
+		if (this.statsActualAppliers.totalRebates) {
+			total += this.statsActualAppliers.totalRebates.modifier
+		}
+		if (this.statsHiddenAppliers?.totalRebates) {
+			total += this.statsHiddenAppliers.totalRebates.modifier;
+		}
+		return total;
+	}
+
+	/**
 	 * Returns the extra hidden costs of the projects (via the `moneySpent` stat key)
 	 */
 	getHiddenCost(): number {
@@ -296,8 +310,8 @@ export class ProjectControl implements ProjectControlParams {
 	/**
 	 * Returns the net cost of this project, including rebates (and in future, surprise hitches)
 	 */
-	getNetCost(): number {
-		return this.cost - this.getRebates() + this.getHiddenCost();
+	getYearEndNetCost(): number {
+		return this.cost - this.getYearEndRebates() + this.getHiddenCost();
 	}
 
 	/**
@@ -399,9 +413,8 @@ export class ProjectControl implements ProjectControlParams {
 			}
 			// IF PROJECT IS NOT ALREADY SELECTED
 			else {
-				let rebates = self.getRebates();
 				// Figure out if this project can be afforded
-				if ((self.cost - rebates) > state.trackedStats.financesAvailable) {
+				if (self.cost > state.trackedStats.financesAvailable) {
 					this.summonSnackbar(<Alert severity='error'>You cannot afford this project with your current budget!</Alert>);
 					return state.currentPage;
 				}
@@ -433,11 +446,12 @@ Projects[Pages.wasteHeatRecovery] = new ProjectControl({
 	},
 	// Stats that 
 	statsActualAppliers: {
-		totalRebates: absolute(5_000),
 		naturalGasMMBTU: absolute(-250),
 	},
 	// Stats that are HIDDEN until AFTER the user commits to the next year. 
-	statsHiddenAppliers: {},
+	statsHiddenAppliers: {
+		totalRebates: absolute(5_000),
+	},
 	title: 'Energy Efficiency - Waste Heat Recovery',
 	shortTitle: 'Upgrade heat recovery on boiler/furnace system',
 	choiceInfoText: [
@@ -568,7 +582,9 @@ Projects[Pages.lightingUpgrades] = new ProjectControl({
 	},
 	statsActualAppliers: {
 		electricityUseKWh: relative(-0.125),
-		totalRebates: absolute(7500),
+	},
+	statsHiddenAppliers: {
+		totalRebates: absolute(7_500),
 	},
 	title: 'Energy Efficiency – Lighting Upgrades',
 	shortTitle: 'Explore lighting upgrades',
@@ -865,6 +881,8 @@ Projects[Pages.compressedAirSystemImprovemnt] = new ProjectControl({
 	},
 	statsActualAppliers: {
 		electricityUseKWh: relative(-0.08),
+	},
+	statsHiddenAppliers: {
 		totalRebates: absolute(5_000),
 	},
 	utilityRebateValue: 5000,
@@ -1022,6 +1040,8 @@ Projects[Pages.improveLightingSystems] = new ProjectControl({
 	},
 	statsActualAppliers: {
 		electricityUseKWh: relative(-0.04),
+	},
+	statsHiddenAppliers: {
 		totalRebates: absolute(10_000),
 	},
 	utilityRebateValue: 10000,
@@ -1084,6 +1104,8 @@ Projects[Pages.installVFDs1] = new ProjectControl({
 	},
 	statsActualAppliers: {
 		electricityUseKWh: relative(-0.04),
+	},
+	statsHiddenAppliers: {
 		totalRebates: absolute(5_000),
 	},
 	utilityRebateValue: 5000,
@@ -1116,6 +1138,8 @@ Projects[Pages.installVFDs2] = new ProjectControl({
 	},
 	statsActualAppliers: {
 		electricityUseKWh: relative(-0.04),
+	},
+	statsHiddenAppliers: {
 		totalRebates: absolute(5_000),
 	},
 	utilityRebateValue: 5000,
@@ -1149,6 +1173,8 @@ Projects[Pages.installVFDs3] = new ProjectControl({
 	},
 	statsActualAppliers: {
 		electricityUseKWh: relative(-0.04),
+	},
+	statsHiddenAppliers: {
 		totalRebates: absolute(5_000),
 	},
 	utilityRebateValue: 5000,

--- a/src/Projects.tsx
+++ b/src/Projects.tsx
@@ -582,6 +582,7 @@ Projects[Pages.lightingUpgrades] = new ProjectControl({
 		url: 'https://betterbuildingssolutioncenter.energy.gov/showcase-projects/lennox-international-led-project-at-new-regional-distribution-leased-location',
 		text: 'In 2016, {Lennox International} in Richardson, Texas implemented LED lighting throughout their warehouse, which resulted in annual energy savings of {$35,000.}'
 	},
+	utilityRebateValue: 5000,
 });
 
 Projects[Pages.electricBoiler] = new ProjectControl({

--- a/src/components/YearRecap.tsx
+++ b/src/components/YearRecap.tsx
@@ -62,9 +62,16 @@ export class YearRecap extends React.Component<YearRecapProps> {
 		const projectRecaps: JSX.Element[] = [];
 		let selectedProjects = [...this.props.selectedProjects].map(project => Projects[project]);
 
-		const utilityRebate: number = selectedProjects.reduce((total, current) => total + Number(current.utilityRebateValue), 0);
-		if (utilityRebate) {
-			const utilityRebateText = `Your project selections qualify you for your local utility’s energy efficiency {rebate program}. You will receive a $\{${utilityRebate.toLocaleString('en-US')} utility credit} for implementing energy efficiency measures.`;
+		let totalUtilityRebates = 0;
+		let rebateProjects = selectedProjects.filter(project => {
+			let rebateValue = Number(project.utilityRebateValue);
+			if (rebateValue) {
+				totalUtilityRebates += rebateValue;
+				return project;
+			}
+		});
+		if (totalUtilityRebates) {
+			const utilityRebateText = `Your project selections qualify you for your local utility’s energy efficiency {rebate program}. You will receive a $\{${totalUtilityRebates.toLocaleString('en-US')} utility credit} for implementing energy efficiency measures.`;
 			projectRecaps.push(
 				<ListItem key={`${utilityRebateText}_surprise_`}>
 					<ThemeProvider theme={darkTheme}>
@@ -72,9 +79,9 @@ export class YearRecap extends React.Component<YearRecapProps> {
 							<CardHeader
 								avatar={
 									<Avatar
-										sx={{ bgcolor: selectedProjects[0].rebateAvatar.backgroundColor, color: selectedProjects[0].rebateAvatar.color }}
+										sx={{ bgcolor: rebateProjects[0].rebateAvatar.backgroundColor, color: rebateProjects[0].rebateAvatar.color }}
 									>
-										{selectedProjects[0].rebateAvatar.icon}
+										{rebateProjects[0].rebateAvatar.icon}
 									</Avatar>
 								}
 								title='Congratulations!'
@@ -82,7 +89,7 @@ export class YearRecap extends React.Component<YearRecapProps> {
 							/>
 							<CardContent>
 								<Typography variant='body1' dangerouslySetInnerHTML={parseSpecialText(utilityRebateText)} />
-									{selectedProjects.map((project, idx) => {
+									{rebateProjects.map((project, idx) => {
 									return <List dense={true} key={project.shortTitle + idx}>
 										<ListItem>
 											<ListItemText

--- a/src/components/YearRecap.tsx
+++ b/src/components/YearRecap.tsx
@@ -189,8 +189,8 @@ export class YearRecap extends React.Component<YearRecapProps> {
 			}
 			// Go through the project's "hidden" stat appliers... but don't create a gauge chart for them.
 			// 	Could do it in one loop and create gauge charts for the sum of actual plus hidden stats, in the future...
-			for (let key in thisProject.statsHiddenAppliers) {
-				let thisApplier: NumberApplier = thisProject.statsHiddenAppliers[key];
+			for (let key in thisProject.statsRecapAppliers) {
+				let thisApplier: NumberApplier = thisProject.statsRecapAppliers[key];
 				let oldValue = mutableStats[key];
 				let newValue = thisApplier.applyValue(oldValue);
 				let difference = newValue - oldValue;


### PR DESCRIPTION
#26 

- Added missing lighting rebate
- Move rebates/roadblocks (surprises) stat appliers to recap
- display roadblocks under rebates
- adjust year end finances available



