### PR TITLE
Eslint Remove semicolon rules

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -39,6 +39,3 @@ rules:
       allowDestructuring: false
       allowedNames: 
         - self
-  semi:
-    - warn
-    - always


### PR DESCRIPTION
There are semi rules which when fixed, prompt another rule saying semicolon unecessary. On top of that semi's don't break js compilation. We don't need this for a project this size